### PR TITLE
Fix LS025 comment logging and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -2847,7 +2847,7 @@ function actualizarLS025(reqId, comentario, clave, pid){
     arr.push(r);
   }else{
     r.valor = "N";
-    r.comentario = r.comentario ? r.comentario+"; "+txt : txt;
+    r.comentario = txt;
     r.autor = USUARIO.correo||"";
     r.modificadoEn = nowIso();
   }
@@ -3000,12 +3000,13 @@ function editarPersona(idx){
     else if(e.target.classList.contains("pf-req-com")){
       if(!p.requisitosObs) p.requisitosObs={};
       p.requisitosObs[e.target.dataset.code]=e.target.value.trim();
-      autoLs025FromPersonal(e.target.dataset.code, e.target.value.trim());
     }
     persistDB(); renderTablaPersonal(); renderDashboard();
   });
   box.addEventListener("change", e=>{
-    if(e.target.classList.contains("pf-req")){
+    if(e.target.classList.contains("pf-req-com")){
+      autoLs025FromPersonal(e.target.dataset.code, e.target.value.trim());
+    }else if(e.target.classList.contains("pf-req")){
       if(!p.requisitos) p.requisitos={};
       const code=e.target.dataset.code;
       p.requisitos[code]=e.target.value;
@@ -3167,12 +3168,13 @@ function editarVehiculo(idx){
     else if(e.target.classList.contains("vf-req-com")){
       if(!v.reqComentarios) v.reqComentarios={};
       v.reqComentarios[e.target.dataset.code]=e.target.value.trim();
-      autoLs025FromVeh(e.target.dataset.code, e.target.value.trim());
     }
     persistDB(); renderTablaVehiculos(); renderDashboard();
   });
   box.addEventListener("change", e=>{
-    if(e.target.classList.contains("vf-req")){
+    if(e.target.classList.contains("vf-req-com")){
+      autoLs025FromVeh(e.target.dataset.code, e.target.value.trim());
+    }else if(e.target.classList.contains("vf-req")){
       if(!v.requisitos) v.requisitos={};
       const code=e.target.dataset.code;
       v.requisitos[code] = e.target.value;


### PR DESCRIPTION
## Summary
- Stop LS025 from logging every keystroke in personal/vehicle comments by logging only on change
- Replace LS025 comment updates instead of appending partial inputs

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8dbc364832d97a0f46904e8d594