### PR TITLE
Fix LS025 comment logging and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -2840,17 +2840,20 @@ function actualizarLS025(reqId, comentario, clave, pid){
   const pr = ensureProyecto(clave,pid);
   if(!pr.ls025) pr.ls025 = {respuestas:[]};
   const arr = pr.ls025.respuestas;
-  let r = arr.find(x=>x.reqId===reqId);
-  const txt = `${USUARIO.nombre}: ${comentario}`;
-  if(!r){
-    r = {reqId, valor:"N", comentario:txt, autor:USUARIO.correo||"", modificadoEn:nowIso()};
-    arr.push(r);
-  }else{
-    r.valor = "N";
-    r.comentario = r.comentario ? r.comentario+"; "+txt : txt;
-    r.autor = USUARIO.correo||"";
-    r.modificadoEn = nowIso();
+  // remove any previous entries for the same requirement
+  for(let i=arr.length-1;i>=0;i--){
+    if(arr[i].reqId===reqId) arr.splice(i,1);
   }
+
+  const txt = comentario.trim();
+  // store comment without automatically prefixing reviewer name
+  arr.push({
+    reqId,
+    valor:"N",
+    comentario:txt,
+    autor:"",
+    modificadoEn:nowIso()
+  });
   persistDB();
   buildLs025();
 }
@@ -2993,19 +2996,22 @@ function editarPersona(idx){
   updateGuiasVisibility();
   $("#modal-persona").style.display="flex";
   box.addEventListener("input", e=>{
+    if(e.target.classList.contains("pf-req-com")){
+      if(!p.requisitosObs) p.requisitosObs={};
+      p.requisitosObs[e.target.dataset.code]=e.target.value.trim();
+      persistDB();
+      return;
+    }
     if(e.target.id==="pf-id") p.personaId=e.target.value.trim();
     else if(e.target.id==="pf-nombre") p.nombre=e.target.value.trim();
     else if(e.target.id==="pf-cargo") p.cargo=e.target.value.trim();
     else if(e.target.id==="pf-com") p.comentarios=e.target.value.trim();
-    else if(e.target.classList.contains("pf-req-com")){
-      if(!p.requisitosObs) p.requisitosObs={};
-      p.requisitosObs[e.target.dataset.code]=e.target.value.trim();
-      autoLs025FromPersonal(e.target.dataset.code, e.target.value.trim());
-    }
     persistDB(); renderTablaPersonal(); renderDashboard();
   });
   box.addEventListener("change", e=>{
-    if(e.target.classList.contains("pf-req")){
+    if(e.target.classList.contains("pf-req-com")){
+      autoLs025FromPersonal(e.target.dataset.code, e.target.value.trim());
+    }else if(e.target.classList.contains("pf-req")){
       if(!p.requisitos) p.requisitos={};
       const code=e.target.dataset.code;
       p.requisitos[code]=e.target.value;
@@ -3159,20 +3165,23 @@ function editarVehiculo(idx){
   box.appendChild(Object.assign(document.createElement("div"),{className:"section",innerHTML:`<label>Comentarios</label><textarea id="vf-com">${v.comentarios||""}</textarea>`}));
   $("#modal-vehiculo").style.display="flex";
   box.addEventListener("input", e=>{
+    if(e.target.classList.contains("vf-req-com")){
+      if(!v.reqComentarios) v.reqComentarios={};
+      v.reqComentarios[e.target.dataset.code]=e.target.value.trim();
+      persistDB();
+      return;
+    }
     if(e.target.id==="vf-id") v.vehiculoId=e.target.value.trim();
     else if(e.target.id==="vf-placa") v.placa=e.target.value.trim();
     else if(e.target.id==="vf-marca") v.marca=e.target.value.trim();
     else if(e.target.id==="vf-tipo") v.tipo=e.target.value.trim();
     else if(e.target.id==="vf-com") v.comentarios=e.target.value.trim();
-    else if(e.target.classList.contains("vf-req-com")){
-      if(!v.reqComentarios) v.reqComentarios={};
-      v.reqComentarios[e.target.dataset.code]=e.target.value.trim();
-      autoLs025FromVeh(e.target.dataset.code, e.target.value.trim());
-    }
     persistDB(); renderTablaVehiculos(); renderDashboard();
   });
   box.addEventListener("change", e=>{
-    if(e.target.classList.contains("vf-req")){
+    if(e.target.classList.contains("vf-req-com")){
+      autoLs025FromVeh(e.target.dataset.code, e.target.value.trim());
+    }else if(e.target.classList.contains("vf-req")){
       if(!v.requisitos) v.requisitos={};
       const code=e.target.dataset.code;
       v.requisitos[code] = e.target.value;


### PR DESCRIPTION
## Summary
- Remove automatic reviewer prefix and deduplicate LS025 comment entries
- Avoid re-render when typing comment inputs to stop duplicate logs in personal/vehicle forms

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8dbc364832d97a0f46904e8d594