### PR TITLE
feat: notify stakeholders via Apps Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ La función de proxy para Gemini también recupera la clave directamente desde l
 - Se envían notificaciones iniciales a SST/MA/RSE y se verifica automáticamente cuando los tres han concluido.
 - El Web App ahora puede recibir datos mediante un formulario que se envía a un iframe oculto y responde usando `postMessage`, lo que permite utilizar el HTML desde `file://` sin errores de CORS. Mantiene además la respuesta JSON con cabeceras `Access-Control-Allow-*` por si se usa `fetch` desde un origen HTTPS.
 - La función `enviarASheet` envía el JSON como `text/plain` para evitar el preflight y captura errores de red si la URL del Web App no es accesible.
-- El Web App ahora registra `correoSST` además de `correoMA` y `correoRSE` y notifica a todos los responsables.
+- El Web App ahora registra `correoSST`, `correoMA`, `correoRSE`, `correoEmp` y `correoResp` y notifica a todos los responsables.
+- Los correos de **Recibido** y **Devolución** se envían desde Apps Script. **Recibido** solo notifica la recepción a SST, MA, RSE, responsable del proyecto y correo de la empresa; **Devolución** adjunta automáticamente el PDF de la carpeta a la empresa y responsable del proyecto.

--- a/code.gs
+++ b/code.gs
@@ -1,0 +1,218 @@
+/**
+ * Google Apps Script Web App backend with additional email fields.
+ */
+
+function doPost(e) {
+  try {
+    if (!e || !e.parameter || !e.parameter.jsonData) {
+      throw new Error('No se recibieron datos en el parámetro "jsonData".');
+    }
+
+    const params = JSON.parse(e.parameter.jsonData);
+    const action = params.action;
+    const rid = (e.parameter && e.parameter.rid) || "";
+
+    let result;
+    if (action === 'askAI') {
+      result = askAIProxy(params.conversation, params.systemInstruction);
+    } else if (action === 'saveToSheet') {
+      result = saveToSheetAndNotify(params.data);
+    } else if (action === 'sendActionEmail') {
+      result = sendActionEmail(params.data);
+    } else {
+      result = saveToSheetAndNotify(params);
+    }
+
+    if (e.parameter && e.parameter.transport === 'iframe') {
+      return wrapAsPostMessage_(result, rid);
+    }
+    return corsJson(result);
+  } catch (err) {
+    Logger.log("Error en doPost: " + err.toString());
+    if (e && e.parameter && e.parameter.transport === 'iframe') {
+      return wrapAsPostMessage_({ error: err.message }, (e.parameter.rid || ""));
+    }
+    return corsJson({ error: err.message });
+  }
+}
+
+function wrapAsPostMessage_(data, rid) {
+  var safe = JSON.stringify({ rid: rid || "", data: data }).replace(/</g, '\\u003c');
+  var html =
+    '<!doctype html><html><body>\n' +
+    '<script>(function(){try{var msg=' + safe + ';parent.postMessage(msg,"*");}catch(e){}})();</script>\n' +
+    'OK</body></html>';
+
+  return HtmlService
+    .createHtmlOutput(html)
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+function corsJson(data) {
+  const out = ContentService.createTextOutput(JSON.stringify(data));
+  out.setMimeType(ContentService.MimeType.JSON);
+  out.setHeader('Access-Control-Allow-Origin', '*');
+  out.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  out.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  return out;
+}
+
+function doOptions() {
+  const out = ContentService.createTextOutput('');
+  out.setMimeType(ContentService.MimeType.TEXT);
+  out.setHeader('Access-Control-Allow-Origin', '*');
+  out.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  out.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  return out;
+}
+
+function askAIProxy(conversation, systemInstruction) {
+  try {
+    const ss = SpreadsheetApp.openById('1chdXUT5JeHwsbAkQA3XoB4px6SjJ4C4IHJM9fBEZhik');
+    const sheet = ss.getSheetByName('Hoja 1');
+    if (!sheet) {
+      throw new Error("No se encontró la 'Hoja 1' para leer la API Key.");
+    }
+    const apiKey = sheet.getRange('P1').getValue();
+    if (!apiKey) {
+      throw new Error('La celda P1 de la Hoja 1 no contiene la API Key de Gemini.');
+    }
+
+    const contents = Array.isArray(conversation)
+      ? conversation
+      : [{ role: 'user', parts: [{ text: String(conversation) }] }];
+
+    const payload = { contents: contents };
+    if (systemInstruction) {
+      payload.systemInstruction = { parts: [{ text: systemInstruction }] };
+    }
+
+    const apiUrl = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=' + apiKey;
+    const options = {
+      method: 'post',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify(payload),
+      muteHttpExceptions: true
+    };
+
+    const response = UrlFetchApp.fetch(apiUrl, options);
+    const data = JSON.parse(response.getContentText());
+    const text = (data && data.candidates && data.candidates[0] && data.candidates[0].content &&
+                  data.candidates[0].content.parts && data.candidates[0].content.parts[0] &&
+                  data.candidates[0].content.parts[0].text) ? data.candidates[0].content.parts[0].text : '';
+
+    return { text: text, raw: data };
+  } catch (e) {
+    Logger.log('Error en askAIProxy: ' + e.toString());
+    return { error: 'Hubo un error al contactar a la IA: ' + e.message };
+  }
+}
+
+function saveToSheetAndNotify(data) {
+  try {
+    const ss = SpreadsheetApp.openById('1chdXUT5JeHwsbAkQA3XoB4px6SjJ4C4IHJM9fBEZhik');
+    const sheet = ss.getSheetByName('Hoja 1');
+
+    if (!sheet) {
+      throw new Error('No se encontró la hoja con el nombre "Hoja 1".');
+    }
+
+    const boliviaTime = Utilities.formatDate(new Date(), "America/La_Paz", "yyyy-MM-dd HH:mm:ss");
+    sheet.appendRow([
+      boliviaTime,
+      data && data.empresaClave || '',
+      data && data.proyectoId || '',
+      data && data.correoSST || '',
+      data && data.correoMA || '',
+      data && data.correoRSE || '',
+      data && data.carpeta || '',
+      data && data.correoEmp || '',
+      data && data.correoResp || ''
+    ]);
+
+    const correos = [data && data.correoSST, data && data.correoMA, data && data.correoRSE, data && data.correoResp, data && data.correoEmp]
+      .filter(Boolean);
+    if (correos.length > 0) {
+      const body = 'Se registró la revisión del proyecto ' + (data && data.proyectoId || '') +
+                   '. Carpeta: ' + (data && data.carpeta || '') +
+                   '\n\nPara seguimiento, use el enlace proporcionado y regístrese con su correo.';
+      MailApp.sendEmail(
+        correos.join(','),
+        'Revisión pendiente: ' + (data && data.proyectoId || ''),
+        body
+      );
+    }
+
+    return { status: "ok", message: "Datos guardados y notificación enviada." };
+  } catch (error) {
+    Logger.log("Error en saveToSheetAndNotify: " + error.toString());
+    return { error: error.message };
+  }
+}
+
+/**
+ * Enviar correos para acciones "Recibido" y "Devolución".
+ * Puede adjuntar un PDF generado a partir de HTML.
+ */
+function sendActionEmail(data) {
+  try {
+    const ss = SpreadsheetApp.openById('1chdXUT5JeHwsbAkQA3XoB4px6SjJ4C4IHJM9fBEZhik');
+    const sheet = ss.getSheetByName('Hoja 1');
+    if (!sheet) {
+      throw new Error('No se encontró la hoja con el nombre "Hoja 1".');
+    }
+
+    const boliviaTime = Utilities.formatDate(new Date(), 'America/La_Paz', 'yyyy-MM-dd HH:mm:ss');
+    sheet.appendRow([
+      boliviaTime,
+      data && data.empresaClave || '',
+      data && data.proyectoId || '',
+      data && data.correoSST || '',
+      data && data.correoMA || '',
+      data && data.correoRSE || '',
+      data && data.carpeta || '',
+      data && data.correoEmp || '',
+      data && data.correoResp || '',
+      data && data.accion || ''
+    ]);
+
+    let destinatarios = [];
+    let subject = '';
+    let body = '';
+
+    if (data.accion === 'Recibido') {
+      destinatarios = [data.correoSST, data.correoMA, data.correoRSE, data.correoResp, data.correoEmp].filter(Boolean);
+      subject = `Carpeta recibida: ${data.empresaClave || ''} ${data.proyectoId || ''}`;
+      body = `Fecha: ${boliviaTime}\nCarpeta: ${data.carpeta || ''}\nProyecto: ${data.proyectoId || ''}\n\nSe ha recibido para su evaluación.\nResponsables asignados:\n- SST: ${data.nomSST || ''}\n- MA: ${data.nomMA || ''}\n- RSE: ${data.nomRSE || ''}\n- Proyecto: ${data.nomResp || ''}\n\nSi quiere hacer seguimiento puede ingresar al siguiente enlace:\nhttps://dmachacap33.github.io/Habilitaci-n-para-Proyectos/\niniciando sesión con su correo proporcionado.\n\nCualquier duda o consulta no dude en comunicarse a la Jefatura de Salud y Seguridad.`;
+
+      if (destinatarios.length > 0) {
+        MailApp.sendEmail(destinatarios.join(','), subject, body);
+      }
+      return { status: 'ok' };
+    }
+
+    if (data.accion === 'Devolución') {
+      destinatarios = [data.correoEmp, data.correoResp].filter(Boolean);
+      subject = data.asunto || `Carpeta devuelta: ${data.empresaClave || ''} ${data.proyectoId || ''}`;
+      body = data.cuerpo || 'Se entregó la carpeta a la empresa.';
+
+      const options = { to: destinatarios.join(','), subject: subject, body: body };
+      if (data.pdfHtml) {
+        const pdf = Utilities.newBlob(data.pdfHtml, 'text/html', 'reporte.html')
+          .getAs('application/pdf')
+          .setName('reporte.pdf');
+        options.attachments = [pdf];
+      }
+      if (destinatarios.length > 0) {
+        MailApp.sendEmail(options);
+      }
+      return { status: 'ok' };
+    }
+
+    return { status: 'sin_accion' };
+  } catch (error) {
+    Logger.log('Error en sendActionEmail: ' + error.toString());
+    return { error: error.message };
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -2058,7 +2058,7 @@ function verificarRevisionesCompletas(clave,pid){
     if(completadas && !yaNotif){
       const creator = pr.proyecto?.capturadoPor || "";
       if(creator){
-        enviarCorreoOutlook(creator, `Revisiones completas ${pid}`, 'SST, MA y RSE finalizaron sus revisiones.');
+        // enviarCorreoOutlook(creator, `Revisiones completas ${pid}`, 'SST, MA y RSE finalizaron sus revisiones.');
       }
       const estSST=estadoLSSST(pr.ls025), estMA=estadoLSMA(pr.ls025), estRSE=estadoLSRSE(pr.ls025);
       const estPer=estadoPersonal(pr.personal), estVeh=estadoVehiculos(pr.vehiculos);
@@ -2685,9 +2685,11 @@ async function crearProyecto(){
   const sst = pr.proyecto?.responsables?.sst?.correo || "";
   const ma  = pr.proyecto?.responsables?.ma?.correo || "";
   const rse = pr.proyecto?.responsables?.rse?.correo || "";
+  const correoEmp = emp?.empresa?.datos?.correo || "";
+  const correoResp = pr.proyecto?.responsables?.proyecto?.correo || "";
   const carpeta = emp?.empresa?.datos?.carpeta || CARPETA_BASE;
-  const payload = {empresaClave:clave, proyectoId:pid, correoSST:sst, correoMA:ma, correoRSE:rse, carpeta};
-  const correos = [sst,ma,rse].filter(Boolean).join(",");
+  const payload = {empresaClave:clave, proyectoId:pid, correoSST:sst, correoMA:ma, correoRSE:rse, correoEmp, correoResp, carpeta};
+  const correos = [sst,ma,rse,correoResp,correoEmp].filter(Boolean).join(",");
   try{
     await enviarASheet(payload);
     // ... (el resto de la lógica de correo se mantiene igual)
@@ -3312,8 +3314,13 @@ function pdfYCorreo(clave,pid,opts={}){
       <div class="no-print" style="margin-top:12px"><button onclick="window.print()">Imprimir / Guardar PDF</button></div>
     </body></html>`;
   w.document.write(html); w.document.close();
-  const correoResp = opts.destinatarios || snap.proyecto?.responsables?.proyecto?.correo || (snap.empresa?.datos?.correo||"");
-  setTimeout(()=>{ window.open(`mailto:${correoResp}?subject=${encodeURIComponent(asunto)}&body=${encodeURIComponent(cuerpo)}`,'_blank'); }, 800);
+  // const correoResp = opts.destinatarios || snap.proyecto?.responsables?.proyecto?.correo || (snap.empresa?.datos?.correo||"");
+  // setTimeout(()=>{ window.open(`mailto:${correoResp}?subject=${encodeURIComponent(asunto)}&body=${encodeURIComponent(cuerpo)}`,'_blank'); }, 800);
+  if(opts.destinatarios){
+    const dests = opts.destinatarios.split(',');
+    const accionEnv = opts.accion || 'Devolución';
+    enviarASheet({action:'sendActionEmail', data:{accion:accionEnv, empresaClave:clave, proyectoId:pid, correoEmp:dests[0]||'', correoResp:dests[1]||'', asunto:opts.asunto, cuerpo:opts.cuerpo, pdfHtml:html}});
+  }
 }
 
 /* ================== Resumen / Export ================== */
@@ -3394,8 +3401,47 @@ function registrarAccion(){
   const pr = ensureProyecto(clave,pid);
   const estSST = estadoLSSST(pr.ls025), estMA = estadoLSMA(pr.ls025), estRSE = estadoLSRSE(pr.ls025);
   const estPer = estadoPersonal(pr.personal), estVeh = estadoVehiculos(pr.vehiculos);
-  registrarRevision(clave,pid,estSST,estMA,estRSE,estPer,estVeh,USUARIO.nombre,$("#rev-accion").value,USUARIO.correo);
-  enviarResultadosRevision(clave,pid);
+  const accion = $("#rev-accion").value;
+  registrarRevision(clave,pid,estSST,estMA,estRSE,estPer,estVeh,USUARIO.nombre,accion,USUARIO.correo);
+  if(accion==="Recibido"){
+    const emp=DBCACHE[clave];
+    const sstObj=pr.proyecto?.responsables?.sst||{};
+    const maObj=pr.proyecto?.responsables?.ma||{};
+    const rseObj=pr.proyecto?.responsables?.rse||{};
+    const respObj=pr.proyecto?.responsables?.proyecto||{};
+    const correoEmp=emp?.empresa?.datos?.correo||"";
+    const payload={
+      action:'sendActionEmail',
+      data:{
+        accion:'Recibido',
+        empresaClave:clave,
+        proyectoId:pid,
+        carpeta:emp?.empresa?.datos?.carpeta||'',
+        correoSST:sstObj.correo||'',
+        correoMA:maObj.correo||'',
+        correoRSE:rseObj.correo||'',
+        correoResp:respObj.correo||'',
+        correoEmp,
+        nomSST:sstObj.nombre||'',
+        nomMA:maObj.nombre||'',
+        nomRSE:rseObj.nombre||'',
+        nomResp:respObj.nombre||''
+      }
+    };
+    enviarASheet(payload);
+  } else if(accion==="Devolución"){
+    const emp=DBCACHE[clave];
+    const empName=emp?.empresa?.datos?.empresa || emp?.empresa?.nombre || clave;
+    const correoEmp=emp?.empresa?.datos?.correo||"";
+    const correoResp=pr.proyecto?.responsables?.proyecto?.correo||"";
+    const destinatarios=[correoEmp,correoResp].filter(Boolean).join(",");
+    if(destinatarios){
+      const allOk=[estSST,estMA,estRSE,estPer,estVeh].every(s=>s==="APROBADO");
+      const asunto=allOk?`Carpeta aprobada ${empName} ${pid}`:`Carpeta revisada ${empName} ${pid}`;
+      const cuerpo=allOk?"Su carpeta ha sido aprobada y puede pasar a recoger su carpeta física." : "Su carpeta fue revisada y se adjunta PDF con observaciones para subsanar.";
+      pdfYCorreo(clave,pid,{destinatarios,asunto,cuerpo,skipRevision:true,accion:'Devolución'});
+    }
+  }
 }
 
 async function notificarSiguiente(){
@@ -3406,41 +3452,26 @@ async function notificarSiguiente(){
   const sst=pr.proyecto?.responsables?.sst?.correo||"";
   const ma=pr.proyecto?.responsables?.ma?.correo||"";
   const rse=pr.proyecto?.responsables?.rse?.correo||"";
+  const correoEmp=emp?.empresa?.datos?.correo||"";
+  const correoResp=pr.proyecto?.responsables?.proyecto?.correo||"";
   const carpeta=emp?.empresa?.datos?.carpeta||CARPETA_BASE;
   const estSST=estadoLSSST(pr.ls025), estMA=estadoLSMA(pr.ls025), estRSE=estadoLSRSE(pr.ls025);
   const estPer=estadoPersonal(pr.personal), estVeh=estadoVehiculos(pr.vehiculos);
-  const payload={empresaClave:clave,proyectoId:pid,correoSST:sst,correoMA:ma,correoRSE:rse,carpeta};
+  const payload={empresaClave:clave,proyectoId:pid,correoSST:sst,correoMA:ma,correoRSE:rse,correoEmp,correoResp,carpeta};
   if(!confirm("¿Notificar a SST/MA/RSE y registrar en la hoja?")) return;
   try{
     const r = await enviarASheet(payload);
     const empName = emp?.empresa?.datos?.empresa || emp?.empresa?.nombre || clave;
     const subject = `Carpeta para habilitar ${empName} ${pid}`;
     const body = `Usted está asignado para revisar la carpeta.\n\nFavor ingresar el siguiente link para su ingreso:\n\n`;
-    [sst,ma,rse].filter(Boolean).forEach((c,i)=>{
-      setTimeout(()=>enviarCorreoOutlook(c, subject, body), i*500);
-    });
+    // [sst,ma,rse,correoResp,correoEmp].filter(Boolean).forEach((c,i)=>{
+    //   setTimeout(()=>enviarCorreoOutlook(c, subject, body), i*500);
+    // });
       registrarRevision(clave,pid,estSST,estMA,estRSE,estPer,estVeh,USUARIO.nombre,"Notificación a SST/MA/RSE",USUARIO.correo);
     alert(r?.status||"Registro enviado");
   }catch(err){
     alert("Error al enviar: "+err.message);
   }
-}
-
-function enviarResultadosRevision(clave,pid){
-  const emp=DBCACHE[clave];
-  const pr=ensureProyecto(clave,pid);
-  const estSST=estadoLSSST(pr.ls025), estMA=estadoLSMA(pr.ls025), estRSE=estadoLSRSE(pr.ls025);
-  const estPer=estadoPersonal(pr.personal), estVeh=estadoVehiculos(pr.vehiculos);
-  if(![estSST,estMA,estRSE].every(s=>s && !s.startsWith("SIN"))) return;
-  const empName=emp?.empresa?.datos?.empresa || emp?.empresa?.nombre || clave;
-  const correoEmp=emp?.empresa?.datos?.correo||"";
-  const correoResp=pr.proyecto?.responsables?.proyecto?.correo||"";
-  const destinatarios=[correoEmp,correoResp].filter(Boolean).join(",");
-  if(!destinatarios) return;
-  const allOk=[estSST,estMA,estRSE,estPer,estVeh].every(s=>s==="APROBADO");
-  const asunto=allOk?`Carpeta aprobada ${empName} ${pid}`:`Carpeta revisada ${empName} ${pid}`;
-  const cuerpo=allOk?"Su carpeta ha sido aprobada y puede pasar a recoger su carpeta física.":"Su carpeta fue revisada y se adjunta PDF con observaciones para subsanar.";
-  pdfYCorreo(clave,pid,{destinatarios,asunto,cuerpo,skipRevision:true});
 }
 
 /* ================== Selectores de empresa/proyecto en paneles ================== */

--- a/outlook-email.js
+++ b/outlook-email.js
@@ -1,6 +1,7 @@
 function enviarCorreoOutlook(destinatario, asunto, cuerpo){
-  const mailto = `mailto:${destinatario}?subject=${encodeURIComponent(asunto)}&body=${encodeURIComponent(cuerpo)}`;
-  window.open(mailto, '_blank');
+  // const mailto = `mailto:${destinatario}?subject=${encodeURIComponent(asunto)}&body=${encodeURIComponent(cuerpo)}`;
+  // window.open(mailto, '_blank');
+  // mailto deshabilitado; envío manejado vía Apps Script
 }
 function emailPath(correo){
   return (correo||'').toLowerCase().replace(/\./g, ',');


### PR DESCRIPTION
## Summary
- send review and return emails through Apps Script instead of mailto
- capture Recibido action to alert SST/MA/RSE, project lead, and company
- deliver Devolución reports with PDF attachments to company and project lead
- Devolución now auto-attaches PDF while Recibido only sends a receipt notice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0bd0f5cc832dabdf80756c3e50f1