### PR TITLE
Fix missing folder path in Recibido email

### DIFF
--- a/index.html
+++ b/index.html
@@ -3700,7 +3700,7 @@ function registrarAccion(){
         accion:'Recibido',
         empresaClave:clave,
         proyectoId:pid,
-        carpeta:emp?.empresa?.datos?.carpeta||'',
+        carpeta:emp?.empresa?.datos?.carpeta||CARPETA_BASE,
         correoSST:sstObj.correo||'',
         correoMA:maObj.correo||'',
         correoRSE:rseObj.correo||'',


### PR DESCRIPTION
## Summary
- ensure "Recibido" notification emails include a default folder path when company folder is undefined

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b198778454832dbd3bed3380c47881