### PR TITLE
Fix project and company refresh without reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -2874,6 +2874,10 @@ async function crearProyecto(){
   };
   DBCACHE[clave] = emp;
   persistDB();
+  renderListaProyectos();
+  renderDashboard();
+  refreshSelectorsAll();
+  renderYPFB();
 
   const pr = emp.proyectos[pid];
   const sst = pr.proyecto?.responsables?.sst?.correo || "";
@@ -2921,6 +2925,11 @@ function guardarEmpresa(){
   };
   ensureEmpresa(clave).empresa = payload;
   persistDB();
+  renderListaProyectos();
+  refreshEmpresaList();
+  refreshSelectorsAll();
+  renderDashboard();
+  renderYPFB();
 }
 function abrirProyecto(clave, pid, ro=false){
   CURRENT.empresaClave = clave; CURRENT.proyectoId = pid; localStorage.setItem("currentV4", JSON.stringify(CURRENT));

--- a/index.html
+++ b/index.html
@@ -2900,6 +2900,11 @@ function eliminarProyecto(clave, pid){
   const emp = DBCACHE[clave]; if(!emp) return;
   delete emp.proyectos[pid];
   persistDB();
+  if(CURRENT.proyectoId===pid){ delete CURRENT.proyectoId; localStorage.setItem("currentV4", JSON.stringify(CURRENT)); }
+  renderListaProyectos();
+  renderDashboard();
+  refreshSelectorsAll();
+  renderYPFB();
 }
 function eliminarEmpresa(){
   const clave = $("#emp-clave").value.trim();


### PR DESCRIPTION
## Summary
- Refresh project list, dashboard, selectors, and YPFB view when creating a new project
- Refresh company data and related UI components after saving an empresa

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b716187dcc832dbbdcc0347955e003