### PR TITLE
Agregar control de visibilidad para personal y vehículos

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@ header{position:sticky;top:0;background:var(--brand);color:#fff;padding:12px 16p
 .btn{border:none;background:var(--brand);color:#fff;font-weight:700;padding:9px 12px;border-radius:12px;cursor:pointer}
 .btn.secondary{background:#fff;color:var(--brand);border:1px solid var(--brand)}
 .btn.ghost{background:transparent;border:1px solid var(--brand);color:var(--brand)}
+.btn.icon{padding:6px 8px;display:inline-flex;align-items:center;justify-content:center}
 .small{font-size:13px}
 .wrap{max-width:1280px;margin:18px auto;padding:0 16px}
 .banner{display:none;margin-top:10px;padding:10px;border:1px dashed var(--border);border-radius:10px;background:#e6efff;color:var(--text)}
@@ -68,6 +69,8 @@ textarea{min-height:80px;resize:vertical}
 .badge.ok{background:rgba(34,197,94,.15);color:var(--ok)}
 .badge.warn{background:rgba(234,179,8,.15);color:var(--warn)}
 .badge.err{background:rgba(239,68,68,.15);color:var(--err)}
+.badge.muted{background:rgba(100,116,139,.2);color:#475569}
+.table tr.row-hidden{opacity:.55}
 .aprob-banner{padding:6px;margin-top:10px;text-align:center;font-weight:bold;border:2px solid}
 .aprob-banner.ok{border-color:var(--ok);color:var(--ok)}
 .aprob-banner.err{border-color:var(--err);color:var(--err)}
@@ -2361,18 +2364,20 @@ function estadoLS(ls){
   return pickGlobal(a,b,c);
 }
 function estadoPersonal(arr){
-  if(!arr || !arr.length) return "SIN PERSONAL";
+  const visibles = (arr||[]).filter(p=>p.visible!==false);
+  if(!visibles.length) return "SIN PERSONAL";
   const vals=[];
-  arr.forEach(p=>{
+  visibles.forEach(p=>{
     Object.values(p.requisitos||{}).forEach(v=>{ if(v && v!=='NA') vals.push(v); });
     (p.guiasMedicas||[]).forEach(g=> Object.values(g.items||{}).forEach(v=>{ if(v && v!=='NA') vals.push(v); }));
   });
   return computeEstadoRapido_SPN(vals);
 }
 function estadoVehiculos(arr){
-  if(!arr || !arr.length) return "SIN VEHICULO";
+  const visibles = (arr||[]).filter(v=>v.visible!==false);
+  if(!visibles.length) return "SIN VEHICULO";
   const vals=[];
-  arr.forEach(v=> Object.values(v.requisitos||{}).forEach(x=>{ if(x && x!=='NA') vals.push(x); }) );
+  visibles.forEach(v=> Object.values(v.requisitos||{}).forEach(x=>{ if(x && x!=='NA') vals.push(x); }) );
   return computeEstadoRapido_SPN(vals);
 }
 function calcularEstados(pr){
@@ -2380,10 +2385,12 @@ function calcularEstados(pr){
   const estSST = tipos.includes('CI') ? estadoLSSST(pr.ls025) : 'NO APLICA';
   const estMA  = tipos.includes('CI') ? estadoLSMA(pr.ls025)  : 'NO APLICA';
   const estRSE = tipos.includes('CI') ? estadoLSRSE(pr.ls025) : 'NO APLICA';
-  const hasPer = tipos.includes('HP') || (pr.personal && pr.personal.length);
-  const hasVeh = tipos.includes('HV') || (pr.vehiculos && pr.vehiculos.length);
-  const estPer = hasPer ? estadoPersonal(pr.personal) : 'NO APLICA';
-  const estVeh = hasVeh ? estadoVehiculos(pr.vehiculos) : 'NO APLICA';
+  const personalVis = (pr.personal||[]).filter(p=>p.visible!==false);
+  const vehiculosVis = (pr.vehiculos||[]).filter(v=>v.visible!==false);
+  const hasPer = tipos.includes('HP') || personalVis.length;
+  const hasVeh = tipos.includes('HV') || vehiculosVis.length;
+  const estPer = hasPer ? estadoPersonal(personalVis) : 'NO APLICA';
+  const estVeh = hasVeh ? estadoVehiculos(vehiculosVis) : 'NO APLICA';
   const estLS  = tipos.includes('CI') ? pickGlobal(estSST, estMA, estRSE) : 'NO APLICA';
   const est    = pickGlobal(estLS, estPer, estVeh);
   return {estSST, estMA, estRSE, estPer, estVeh, estLS, est};
@@ -2747,11 +2754,11 @@ function drawAllCharts(){
     const emp=DBCACHE[clave];
     Object.values(emp.proyectos||{}).forEach(pr=>{
       (pr.ls025?.respuestas||[]).forEach(r=>{ if(r.valor==="N") n++; });
-      (pr.personal||[]).forEach(p=>{
+      (pr.personal||[]).filter(p=>p.visible!==false).forEach(p=>{
         Object.values(p.requisitos||{}).forEach(v=>{ if(v==="N") n++; });
         (p.guiasMedicas||[]).forEach(g=>Object.values(g.items||{}).forEach(v=>{ if(v==="N") n++; }));
       });
-      (pr.vehiculos||[]).forEach(v=> Object.values(v.requisitos||{}).forEach(x=>{ if(x==="N") n++; }));
+      (pr.vehiculos||[]).filter(v=>v.visible!==false).forEach(v=> Object.values(v.requisitos||{}).forEach(x=>{ if(x==="N") n++; }));
     });
     const name = emp.empresa?.datos?.empresa || emp.empresa?.nombre || clave;
     counts.push({name, n});
@@ -3097,7 +3104,7 @@ function autoLs025FromPersonal(code){
   const clave=$("#per-empresaSel").value;
   const pid=$("#per-proyectoSel").value;
   const pr = proyectoActualPersonal();
-  const personas = pr.personal || [];
+  const personas = (pr.personal || []).filter(p=>p.visible!==false);
   let allS = personas.length>0;
   let anyN = false;
   const comentarios=[];
@@ -3127,7 +3134,7 @@ function autoLs025FromVeh(code){
   const clave=$("#veh-empresaSel").value;
   const pid=$("#veh-proyectoSel").value;
   const pr = proyectoActualVeh();
-  const vehiculos = pr.vehiculos || [];
+  const vehiculos = (pr.vehiculos || []).filter(v=>v.visible!==false);
   let allS = vehiculos.length>0;
   let anyN = false;
   const comentarios=[];
@@ -3173,7 +3180,7 @@ function agregarPersona(){
   const nombre=$("#per-nombre").value.trim(); const cargo=$("#per-cargo").value.trim();
   const personaId=$("#per-id").value.trim()||("PER-"+Math.floor(Math.random()*9000+1000));
   if(!nombre){ alert("Ingrese el nombre"); return; }
-  pr.personal.push({personaId,nombre,cargo,requisitos:{},guiasMedicas:[],comentarios:""});
+  pr.personal.push({personaId,nombre,cargo,requisitos:{},guiasMedicas:[],comentarios:"",visible:true});
 
   const clave=$("#per-empresaSel").value, pid=$("#per-proyectoSel").value;
   logProyecto(clave,pid);
@@ -3189,6 +3196,7 @@ function renderTablaPersonal(){
   const addBtn=$("#panel-personal .section .row button"); if(addBtn) addBtn.disabled=READONLY;
   const tb=$("#tabla-personal tbody"); tb.innerHTML="";
   (pr.personal||[]).forEach((p,idx)=>{
+    const isVisible = p.visible !== false;
     const reqVals = Object.values(p.requisitos||{}).filter(v=>v && v!=='NA');
     const guiaVals = [];
     (p.guiasMedicas||[]).forEach(g=> Object.values(g.items||{}).forEach(v=>{ if(v && v!=='NA') guiaVals.push(v); }));
@@ -3203,16 +3211,21 @@ function renderTablaPersonal(){
       })
       .map(g=>g.perfil.replaceAll('_',' ')).join(", ");
     const tr = document.createElement("tr");
-    const acciones = READONLY?"":`<button class="btn small" onclick="editarPersona(${idx})">Editar</button> <button class="btn secondary small" onclick="eliminarPersona(${idx})">Eliminar</button>`;
+    if(!isVisible) tr.classList.add("row-hidden");
+    const estado = isVisible ? "" : ` <span class="badge muted">Oculto</span>`;
+    const toggleTitle = isVisible ? "Ocultar de la validación" : "Mostrar y considerar";
+    const toggleIcon = isVisible ? "👁️" : "🙈";
+    const toggleBtn = `<button class="btn ghost small icon" ${READONLY?'disabled':''} onclick="togglePersonaVisible(${idx})" title="${toggleTitle}">${toggleIcon}</button>`;
+    const acciones = READONLY?toggleBtn:`${toggleBtn} <button class="btn small" onclick="editarPersona(${idx})">Editar</button> <button class="btn secondary small" onclick="eliminarPersona(${idx})">Eliminar</button>`;
     tr.innerHTML = `
-      <td>${p.personaId}</td><td>${p.nombre}</td><td>${p.cargo||""}</td><td>${fs}</td><td>${apto||"-"}</td>
+      <td>${p.personaId}</td><td>${p.nombre}${estado}</td><td>${p.cargo||""}</td><td>${fs}</td><td>${apto||"-"}</td>
       <td><span class="badge ${perc===100?'ok':(perc>=60?'warn':'err')}">${perc}%</span></td>
       <td>${acciones}</td>`;
     tb.appendChild(tr);
   });
-  }
+}
 
-  function updateNuevoProyectoBtn(){
+function updateNuevoProyectoBtn(){
   const btn = document.getElementById('btn-nuevo-proyecto');
   if(!btn) return;
   const clave = $("#emp-clave").value.trim();
@@ -3230,6 +3243,22 @@ function eliminarPersona(idx){
   logProyecto(clave,pid);
 
   persistPersonal();
+}
+function togglePersonaVisible(idx){
+  const pr = proyectoActualPersonal();
+  const persona = pr.personal?.[idx];
+  if(!persona || READONLY) return;
+  persona.visible = persona.visible===false ? true : false;
+
+  const clave=$("#per-empresaSel").value, pid=$("#per-proyectoSel").value;
+  logProyecto(clave,pid);
+
+  syncLs025FromPersona();
+  persistPersonal();
+  renderTablaPersonal();
+  renderDashboard();
+  renderResumen();
+  buildLs025();
 }
 function editarPersona(idx){
   if(READONLY) return;
@@ -3405,7 +3434,7 @@ function agregarVehiculo(){
   const placa=$("#veh-placa").value.trim(); if(!placa){ alert("Ingrese la placa"); return; }
   const vehiculoId=$("#veh-id").value.trim()||("VEH-"+placa.replace(/[^A-Za-z0-9]/g,"").toUpperCase());
   const marca=$("#veh-marca").value.trim(); const tipo=$("#veh-tipo").value.trim();
-  pr.vehiculos.push({vehiculoId, placa, marca, tipo, requisitos:{}, comentarios:""});
+  pr.vehiculos.push({vehiculoId, placa, marca, tipo, requisitos:{}, comentarios:"", visible:true});
 
   const clave=$("#veh-empresaSel").value, pid=$("#veh-proyectoSel").value;
   logProyecto(clave,pid);
@@ -3421,13 +3450,19 @@ function renderTablaVehiculos(){
   const addBtn=$("#panel-vehiculos .section .row button"); if(addBtn) addBtn.disabled=READONLY;
   const tb=$("#tabla-vehiculos tbody"); tb.innerHTML="";
   (pr.vehiculos||[]).forEach((v,idx)=>{
+    const isVisible = v.visible !== false;
     const vals=Object.values(v.requisitos||{}).filter(x=>x && x!=='NA');
     const done=vals.filter(x=>x==="S").length;
     const perc=Math.round((done/Math.max(1,vals.length))*100);
     const tr=document.createElement("tr");
-    const acciones = READONLY?"":`<button class="btn small" onclick="editarVehiculo(${idx})">Editar</button> <button class="btn secondary small" onclick="eliminarVehiculo(${idx})">Eliminar</button>`;
+    if(!isVisible) tr.classList.add("row-hidden");
+    const estado = isVisible ? "" : ` <span class="badge muted">Oculto</span>`;
+    const toggleTitle = isVisible ? "Ocultar de la validación" : "Mostrar y considerar";
+    const toggleIcon = isVisible ? "👁️" : "🙈";
+    const toggleBtn = `<button class="btn ghost small icon" ${READONLY?'disabled':''} onclick="toggleVehiculoVisible(${idx})" title="${toggleTitle}">${toggleIcon}</button>`;
+    const acciones = READONLY?toggleBtn:`${toggleBtn} <button class="btn small" onclick="editarVehiculo(${idx})">Editar</button> <button class="btn secondary small" onclick="eliminarVehiculo(${idx})">Eliminar</button>`;
     tr.innerHTML = `
-      <td>${v.vehiculoId}</td><td>${v.placa}</td><td>${v.marca||""}</td><td>${v.tipo||""}</td>
+      <td>${v.vehiculoId}</td><td>${v.placa}${estado}</td><td>${v.marca||""}</td><td>${v.tipo||""}</td>
       <td><span class="badge ${perc===100?'ok':(perc>=60?'warn':'err')}">${perc}%</span></td>
       <td>${acciones}</td>`;
     tb.appendChild(tr);
@@ -3442,6 +3477,22 @@ function eliminarVehiculo(idx){
   logProyecto(clave,pid);
 
   persistVehiculos();
+}
+function toggleVehiculoVisible(idx){
+  const pr = proyectoActualVeh();
+  const vehiculo = pr.vehiculos?.[idx];
+  if(!vehiculo || READONLY) return;
+  vehiculo.visible = vehiculo.visible===false ? true : false;
+
+  const clave=$("#veh-empresaSel").value, pid=$("#veh-proyectoSel").value;
+  logProyecto(clave,pid);
+
+  syncLs025FromVehiculo();
+  persistVehiculos();
+  renderTablaVehiculos();
+  renderDashboard();
+  renderResumen();
+  buildLs025();
 }
 function editarVehiculo(idx){
   if(READONLY) return;
@@ -3576,7 +3627,9 @@ function buildPdfHtml(clave,pid){
     return `<table><thead><tr><th>ID</th><th>Requisito</th><th>S/N/NA</th><th>Comentario</th></tr></thead><tbody>${rows}</tbody></table>`;
   };
   const tablePer = ()=>{
-    const rows = (snap.personal||[]).map(p=>{
+    const personalVis = (snap.personal||[]).filter(p=>p.visible!==false);
+    const hidden = (snap.personal||[]).length - personalVis.length;
+    const rows = personalVis.map(p=>{
       let bad=[]; Object.entries(p.requisitos||{}).forEach(([k,v])=>{ if(v==="N") bad.push(k); });
       (p.guiasMedicas||[]).forEach(g=> Object.entries(g.items||{}).forEach(([k,v])=>{ if(v==="N") bad.push(k); }));
       const fs = (p.requisitos||{}).P_RIESGO_FS100 || '';
@@ -3588,16 +3641,20 @@ function buildPdfHtml(clave,pid){
         .map(g=>g.perfil.replaceAll('_',' ')).join(", ");
       return `<tr><td>${p.nombre}</td><td>${p.cargo||''}</td><td>${fs}</td><td>${apto}</td><td>${bad.join(", ")}</td></tr>`;
     }).join("") || "<tr><td colspan='5'>Sin personal</td></tr>";
-    return `<table><thead><tr><th>Persona</th><th>Cargo</th><th>FS100</th><th>Apto</th><th>Observaciones (NO)</th></tr></thead><tbody>${rows}</tbody></table>`;
+    const note = hidden>0 ? `<div style="font-size:12px;color:#555;margin:6px 0;">${hidden} persona(s) ocultas.</div>` : "";
+    return `${note}<table><thead><tr><th>Persona</th><th>Cargo</th><th>FS100</th><th>Apto</th><th>Observaciones (NO)</th></tr></thead><tbody>${rows}</tbody></table>`;
   };
   const tableVeh = ()=>{
-    const rows = (snap.vehiculos||[]).map(v=>{
+    const vehVis = (snap.vehiculos||[]).filter(v=>v.visible!==false);
+    const hidden = (snap.vehiculos||[]).length - vehVis.length;
+    const rows = vehVis.map(v=>{
       const vals = Object.values(v.requisitos||{}).filter(x=>x && x!=='NA');
       const bad = Object.entries(v.requisitos||{}).filter(([k,val])=>val==="N").map(([k])=>k).join(", ");
       const est = computeEstadoRapido_SPN(vals);
       return `<tr><td>${v.placa}</td><td>${(v.marca||'')+' '+(v.tipo||'')}</td><td>${est}</td><td>${bad}</td></tr>`;
     }).join("") || "<tr><td colspan='4'>Sin vehículos</td></tr>";
-    return `<table><thead><tr><th>Placa</th><th>Marca/Tipo</th><th>Estado</th><th>Observaciones (NO)</th></tr></thead><tbody>${rows}</tbody></table>`;
+    const note = hidden>0 ? `<div style="font-size:12px;color:#555;margin:6px 0;">${hidden} vehículo(s) ocultos.</div>` : "";
+    return `${note}<table><thead><tr><th>Placa</th><th>Marca/Tipo</th><th>Estado</th><th>Observaciones (NO)</th></tr></thead><tbody>${rows}</tbody></table>`;
   };
   const tableEnt = ()=>{
     const hist = (snap.historial||[])
@@ -3699,6 +3756,10 @@ function renderResumen(){
   const snap = buildSnapshot(clave,pid);
   const totalLS=CATALOG_LS025.length; let s=0;
   (snap.ls025?.respuestas||[]).forEach(r=>{ if(r.valor==="S") s++; });
+  const personalVisible = (snap.personal||[]).filter(p=>p.visible!==false);
+  const vehiculosVisibles = (snap.vehiculos||[]).filter(v=>v.visible!==false);
+  const perOcultos = (snap.personal||[]).length - personalVisible.length;
+  const vehOcultos = (snap.vehiculos||[]).length - vehiculosVisibles.length;
   const histEnt = (snap.historial||[]).filter(h=>h.accion==="Recibido" || h.accion==="Devolución");
   const histVer = (snap.historial||[]).filter(h=>h.accion!=="Recibido" && h.accion!=="Devolución");
   let revEnt=0,lastEnt=0;
@@ -3751,8 +3812,8 @@ function renderResumen(){
       <div>Empresa: <b>${snap.empresa?.datos?.empresa || snap.empresa?.nombre || clave}</b></div>
       <div>Proyecto: <b>${snap.proyecto?.proyectoId||pid}</b></div>
       <div>LS.025 (S): <b>${s}/${totalLS}</b></div>
-      <div>Personal: <b>${(snap.personal||[]).length}</b></div>
-      <div>Vehículos: <b>${(snap.vehiculos||[]).length}</b></div>
+      <div>Personal: <b>${personalVisible.length}</b>${perOcultos>0?` <span class="note">(${perOcultos} ocultos)</span>`:""}</div>
+      <div>Vehículos: <b>${vehiculosVisibles.length}</b>${vehOcultos>0?` <span class="note">(${vehOcultos} ocultos)</span>`:""}</div>
     </div>
       <div class="section" style="margin-top:10px">
         <h4>Recepción / Devolución</h4>


### PR DESCRIPTION
## Resumen
- agregar botones de ojo para ocultar o volver a mostrar personas y vehículos sin eliminarlos
- excluir los registros ocultos de los cálculos de aprobación, sincronización LS.025, reportes y métricas
- mostrar indicadores visuales y notas que aclaran cuántos elementos están ocultos

## Pruebas
- no se ejecutaron pruebas automatizadas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_68c9b9429cbc832db11c8390ddc16a73