### PR TITLE
Evitar salto de layout móvil al enfocar filtros

### DIFF
--- a/index.html
+++ b/index.html
@@ -1616,10 +1616,13 @@ const $ = s => document.querySelector(s);
 const $$ = s => Array.from(document.querySelectorAll(s));
 
 function applyMobileViewportFix(){
-  const viewport = window.visualViewport;
-  const width = viewport ? viewport.width : window.innerWidth;
   const body = document.body;
   if(!body) return;
+  const doc = document.documentElement;
+  const width = Math.min(
+    window.innerWidth || 0,
+    doc ? doc.clientWidth : Number.POSITIVE_INFINITY
+  );
   if(width <= 768){
     body.classList.add('mobile-viewport');
   }else{


### PR DESCRIPTION
## Summary
- Evitar que el ancho detectado para activar el layout móvil use visualViewport y se dispare cuando iOS aplica zoom al enfocar campos
- Calcular el ancho en base a window.innerWidth y documentElement.clientWidth para mantener el layout móvil estable mientras el usuario interactúa con los filtros

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5d806ae54832d97bb2a2a1f2961a5